### PR TITLE
Add posters, DVB genre mapping and richer TVHeadend integration (builds on #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,16 @@ The following options are supported in TVHeadend mode:
   TVHeadend to run on a different port.
 - `--tvh-username`: The username to use for connecting to TVHeadend. This can (and should) be a user with limited access.
 - `--tvh-password`: The password to use for connecting to TVHeadend. Note that this password can be seen on the command line.
-- `--tvh-socket SOCKET`: The path to xmltv socket of TVHeadend, used to write the XMLTV data. Defaults to
+- `--tvh-username-env`: The name of an environment variable to read the TVHeadend username from. Can be used instead of
+  `--tvh-username`.
+- `--tvh-password-env`: The name of an environment variable to read the TVHeadend password from. Can be used instead of
+  `--tvh-password` to avoid the password being visible on the command line.
+- `--tvh-socket SOCKET`: The path to xmltv socket of TVHeadend, used to write the XMLTV data. By default the path is
+  requested from the TVHeadend API (which requires a user with admin rights), falling back to
   `/home/hts/.hts/tvheadend/epggrab/xmltv.sock` which should work for any installation that installed TVHeadend under the
   recommended system user. Note that this socket file _only_ exists if the XMLTV grabber was enabled in TVHeadend.
+- `--tvh-network NETWORK`: Only use channels that have at least one service on the network with this name (for example
+  `Ziggo`). The name is compared case-insensitively. By default all TVHeadend channels are used.
 
 The following options are supported in standalone file mode:
 - `--channel-file`: Sets the filename of the file to read (or write, see `--write-channel-list`) the channel list from. This can

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ The following options are tweaks that can be used by advanced users:
 - `--database-location`: By default the `ziggoepg_cache.sqlite` file is stored in the working directory of the script. Should you
   desire a different location (for example, a file system that is better suited to handle a database file), an alternative path
   (but not filename) can be specified here.
+- `--vacuum-interval`: The number of days between vacuums (defragmentation rebuilds) of the cache database. Vacuuming keeps
+  the database from getting fragmented, but rebuilds the entire database file every time. The default of 7 vacuums at most
+  once a week. Set to 0 to vacuum on every grab (the old behavior).
 - `--generate-only`: Great for testing the export of the XMLTV data. No contact is made with the ZiggoGo servers, the XMLTV
   generation is done fully from the existing `ziggoepg_cache.sqlite` file. Any useful application of this mode requires ZiggoGo
   EPG to have run in a normal mode at least once before. Note that this option is ignored if the `--write-channel-list` option

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ ZiggoGo EPG supports the following basic options:
   the servers. To reduce grabbing time, memory use and storgae requirements, this value can be lowered.
 - `-f`, `--file-mode`: Runs the grabber in file mode instead of the default TVHeadend mode. See the
   [TVHeadend mode](#tvheadend-mode) and [Standalone mode](#standalone-mode) sections for a detailed explanation.
+- `-q`, `--quiet`: Only log warnings and errors, suppressing the progress messages. Useful when running the grabber
+  non-interactively, for example from cron or a systemd timer.
 
 The following options are supported in TVHeadend mode:
 - `--tvh-host`: Give the hostname of the TVHeadend server. Defaults to `localhost`, which should be safe as writing the XMLTV file

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ The following configuration options are available:
     one `{}` entry, which is to be placed in the location of the URL where the program id is normally placed. A program id is a
     long string that is associated with the program. This value can be seen both in the segment data and from observing the URL
     called by the online viewing application from your local provider.
+  - `epg_img_detail`: Optional. The URL where the grabber can get the program poster images. The URL must have exactly two `{}`
+    entries: the first is filled in with the eventId (the full crid+imi string as found in the program details) and the second
+    with the imageVersion. If this URL is not configured, no program icons are added to the XMLTV file.
 - `timezone`: The timezone that is used for creating program entries in the XMLTV file. This timezone must be supported by
   `pytz`. See the explanation of the `--timezone` option for what is allowed here.
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,9 @@ Thank you [Beralt](https://github.com/beralt) for your hard work on [horepg](htt
 
 Also thanks to:
 - [ldymek](https://github.com/ldymek) for providing the configuration information for `upc-pl`.
+- [BertusG](https://github.com/BertusG) for the ideas behind the programme poster images, the Dutch-to-DVB genre mapping and
+  the scheduled database vacuum (first proposed in [PR #9](https://github.com/jbogers/ziggogo-epg/pull/9)).
 
 ## TODO's
 
 - Add a setup.cfg/setup.py file to make the program installable as a Python module for the people who perfer that run mode.
-- Implement an optional category translation similar to 'https://github.com/beralt/horepg/blob/master/horepg/xmltvdoc.py' in 
-  XMLTVWriter to have proper category mapping in TVHeadend.
-  - Translated categories should be additionally added as the original data may be applicable for other applications.

--- a/classes/tvsystemio.py
+++ b/classes/tvsystemio.py
@@ -31,68 +31,124 @@ class TVSystemIo:
 class TVHeadendIo(TVSystemIo):
     """Class used to interact with TVHeadend for the EPG"""
 
+    DEFAULT_XMLTV_SOCKET_PATH = "/home/hts/.hts/tvheadend/epggrab/xmltv.sock"
+
     def __init__(
         self,
         host="localhost",
         port=9981,
         username="",
         password="",
-        xmltv_socket_path="/home/hts/.hts/tvheadend/epggrab/xmltv.sock",
+        xmltv_socket_path=None,
+        network=None,
     ):
-        """Initialize the TVHeadendIo class"""
+        """
+        Initialize the TVHeadendIo class
+
+        :param xmltv_socket_path: Path to the xmltv socket of TVHeadend. If None, the path is requested from the
+                                  TVHeadend API, falling back to DEFAULT_XMLTV_SOCKET_PATH if that fails.
+        :param network: If given, get_channel_list only returns channels that have at least one service on the
+                        network with this name (compared case-insensitively).
+        """
         self._host = host
         self._port = port
         self._username = username
         self._password = password
         self._xmltv_socket_path = xmltv_socket_path
+        self._network = network
 
-    def get_channel_list(self) -> List[str]:
-        """Get the list of channels from TVHeadend"""
-        logging.info("Requesting known channel list from TVHeadend...")
+    def _api_get(self, path, params=None):
+        """Perform a GET request on the TVHeadend API and return the decoded JSON response"""
+        url = f"http://{self._host}:{self._port}/api/{path}"
         try:
-            r = requests.get(
-                f"http://{self._host}:{self._port}/api/channel/list",
-                auth=HTTPBasicAuth(username=self._username, password=self._password),
-            )
+            r = requests.get(url, params=params, auth=HTTPBasicAuth(username=self._username, password=self._password))
+            if r.status_code == 401:
+                # Also try Digest authentication
+                r.close()
+                r = requests.get(url, params=params, auth=HTTPDigestAuth(username=self._username, password=self._password))
         except requests.ConnectionError:
             raise TVSystemIoException(f"Could not connect to TVHeadend on http://{self._host}:{self._port}.")
 
-        if r.status_code == 401:
-            # Also try Digest authentication
-            r.close()
-            r = requests.get(
-                f"http://{self._host}:{self._port}/api/channel/list",
-                auth=HTTPDigestAuth(username=self._username, password=self._password),
-            )
         if r.status_code != 200:
-            raise TVSystemIoException(f"Error getting channel list from TVHeadend. The status code was: {r.status_code}")
+            raise TVSystemIoException(f"Error calling TVHeadend api '{path}'. The status code was: {r.status_code}")
 
         try:
-            channeldata = r.json()
+            return r.json()
         except requests.exceptions.JSONDecodeError:
-            raise TVSystemIoException(f"Error getting channel list from TVHeadend. The list was not valid JSON data.")
+            raise TVSystemIoException(f"Error calling TVHeadend api '{path}'. The response was not valid JSON data.")
 
+    def get_channel_list(self) -> List[str]:
+        """Get the list of channels from TVHeadend"""
+        if self._network is None:
+            logging.info("Requesting known channel list from TVHeadend...")
+            channeldata = self._api_get("channel/list")
+            try:
+                return [channel["val"] for channel in channeldata["entries"]]
+            except KeyError:
+                raise TVSystemIoException(f"Error getting channel list from TVHeadend. The list was not structured properly.")
+
+        logging.info(f"Requesting known channel list for network '{self._network}' from TVHeadend...")
+        servicedata = self._api_get("mpegts/service/grid", params={"limit": 999999, "list": "network"})
+        channeldata = self._api_get("channel/grid", params={"limit": 999999, "list": "enabled,name,services"})
+
+        network = self._network.lower()
         try:
-            channellist = [channel["val"] for channel in channeldata["entries"]]
+            network_services = {
+                service["uuid"] for service in servicedata["entries"] if service.get("network", "").lower() == network
+            }
+            channellist = [
+                channel["name"]
+                for channel in channeldata["entries"]
+                if channel.get("enabled") and not network_services.isdisjoint(channel.get("services", []))
+            ]
         except KeyError:
             raise TVSystemIoException(f"Error getting channel list from TVHeadend. The list was not structured properly.")
 
+        if not channellist:
+            logging.warning(f"No channels found on a network named '{self._network}'.")
         return channellist
+
+    def _discover_xmltv_socket(self) -> str:
+        """
+        Ask TVHeadend for the socket path of the external XMLTV grabber module.
+
+        Falls back to DEFAULT_XMLTV_SOCKET_PATH if the path cannot be determined (for example because the
+        configured user has no admin rights on the TVHeadend API).
+        """
+        try:
+            moduledata = self._api_get("idnode/load", params={"class": "epggrab_mod_ext"})
+            for module in moduledata.get("entries", []):
+                params = {param.get("id"): param.get("value") for param in module.get("params", [])}
+                if params.get("path"):
+                    logging.info(f"TVHeadend reports the xmltv socket at '{params['path']}'.")
+                    return params["path"]
+        except TVSystemIoException as ex:
+            logging.warning(str(ex))
+
+        logging.info(
+            f"Could not determine the xmltv socket path from the TVHeadend API, "
+            f"using '{self.DEFAULT_XMLTV_SOCKET_PATH}'."
+        )
+        return self.DEFAULT_XMLTV_SOCKET_PATH
 
     def write_xmltv(self, data: bytes):
         """Write the XMLTV EPG to TVHeadend directly"""
+        socket_path = self._xmltv_socket_path
+        if socket_path is None:
+            socket_path = self._discover_xmltv_socket()
+
         logging.info("Writing XMLTV directly to TVHeadend...")
         try:
             sock = socket.socket(socket.AF_UNIX)
             try:
-                sock.connect(self._xmltv_socket_path)
+                sock.connect(socket_path)
                 sock.sendall(data)
             finally:
                 sock.close()
 
         except OSError:
             raise TVSystemIoException(
-                f"Error writing XMLTV to '{self._xmltv_socket_path}'. Is the path correct, "
+                f"Error writing XMLTV to '{socket_path}'. Is the path correct, "
                 f"is TVHeadend running and was the XMLTV EPG grabber enabled?"
             )
 

--- a/classes/tvsystemio.py
+++ b/classes/tvsystemio.py
@@ -23,6 +23,9 @@ class TVSystemIo:
         """Get the list of channels to grab the EPG for"""
         raise NotImplementedError()
 
+    def preflight(self):
+        """Verify the XMLTV output destination is usable, so a misconfiguration fails before a lengthy grab"""
+
     def write_xmltv(self, data: bytes):
         """Write the XMLTV EPG to storage"""
         raise NotImplementedError()
@@ -134,6 +137,25 @@ class TVHeadendIo(TVSystemIo):
             f"using '{self.DEFAULT_XMLTV_SOCKET_PATH}'."
         )
         return self.DEFAULT_XMLTV_SOCKET_PATH
+
+    def preflight(self):
+        """Check that the xmltv socket accepts connections, so a misconfiguration fails before a lengthy grab"""
+        if self._xmltv_socket_path is None:
+            self._xmltv_socket_path = self._discover_xmltv_socket()
+
+        logging.info(f"Checking that the xmltv socket at '{self._xmltv_socket_path}' accepts connections...")
+        try:
+            sock = socket.socket(socket.AF_UNIX)
+            try:
+                sock.connect(self._xmltv_socket_path)
+            finally:
+                sock.close()
+
+        except OSError:
+            raise TVSystemIoException(
+                f"Cannot connect to the xmltv socket at '{self._xmltv_socket_path}'. Is the path correct, "
+                f"is TVHeadend running and was the XMLTV EPG grabber enabled?"
+            )
 
     def write_xmltv(self, data: bytes):
         """Write the XMLTV EPG to TVHeadend directly"""

--- a/classes/tvsystemio.py
+++ b/classes/tvsystemio.py
@@ -105,7 +105,11 @@ class TVHeadendIo(TVSystemIo):
             raise TVSystemIoException(f"Error getting channel list from TVHeadend. The list was not structured properly.")
 
         if not channellist:
-            logging.warning(f"No channels found on a network named '{self._network}'.")
+            available = sorted({service["network"] for service in servicedata["entries"] if service.get("network")})
+            logging.warning(
+                f"No channels found on a network named '{self._network}'. "
+                f"Available networks: {', '.join(repr(name) for name in available) or 'none'}."
+            )
         return channellist
 
     def _discover_xmltv_socket(self) -> str:

--- a/classes/xmltvwriter.py
+++ b/classes/xmltvwriter.py
@@ -14,6 +14,197 @@ from lxml import etree
 class XMLTVWriter:
     """Write XMLTV data from database"""
 
+    # Mapping of Ziggo genre names to the DVB (ETSI EN 300 468) category names known by TVHeadend.
+    # Ziggo genres are free-form and hand-typed, so keys are lowercase and matched case-insensitively.
+    GENRE_MAP = {
+        # Movies
+        "film": "Movie / Drama",
+        "actie": "Adventure / Western / War",
+        "avontuur": "Adventure / Western / War",
+        "animatie": "Cartoons / Puppets",
+        "anime": "Cartoons / Puppets",
+        "komedie": "Comedy",
+        "romantische komedie": "Comedy",
+        "standup komedie": "Comedy",
+        "zwarte komedie": "Comedy",
+        "sitcoms": "Comedy",
+        "documentaire": "Documentary",
+        "docudrama": "Documentary",
+        "docusoap": "Documentary",
+        "drama": "Movie / Drama",
+        "dramaseries": "Movie / Drama",
+        "historisch drama": "Serious / Classical / Religious / Historical movie / Drama",
+        "misdaaddrama": "Detective / Thriller",
+        "miniseries": "Movie / Drama",
+        "fantasy": "Science fiction / Fantasy / Horror",
+        "sciencefiction": "Science fiction / Fantasy / Horror",
+        "horror": "Science fiction / Fantasy / Horror",
+        "thriller": "Detective / Thriller",
+        "mysterie": "Detective / Thriller",
+        "misdaad": "Detective / Thriller",
+        "romantiek": "Romance",
+        "western": "Adventure / Western / War",
+        "oorlog": "Adventure / Western / War",
+        "musical": "Musical / Opera",
+        "biografie": "Documentary",
+        # News and current affairs
+        "nieuws": "News / Current affairs",
+        "actualiteit": "News / Current affairs",
+        "actualiteitenprogramma's": "News / Current affairs",
+        "debat": "Discussion / Interview / Debate",
+        "politiek": "Social / Political issues / Economics",
+        "politieke satire": "Social / Political issues / Economics",
+        "interview": "Discussion / Interview / Debate",
+        "business & financial": "News / Current affairs",
+        "weer": "News / Weather report",
+        # Sports
+        "sport": "Sports",
+        "voetbal": "Football / Soccer",
+        "american football": "Team sports (excluding football)",
+        "basketbal": "Team sports (excluding football)",
+        "tennis": "Tennis / Squash",
+        "golf": "Sports",
+        "atletiek": "Athletics",
+        "wielrennen": "Sports",
+        "motorsport": "Motor sport",
+        "motorracen": "Motor sport",
+        "rugby": "Team sports (excluding football)",
+        "rugby league": "Team sports (excluding football)",
+        "rugby union": "Team sports (excluding football)",
+        "honkbal": "Team sports (excluding football)",
+        "cricket": "Team sports (excluding football)",
+        "volleybal": "Team sports (excluding football)",
+        "darts": "Sports",
+        "snooker": "Sports",
+        "paardensport": "Equestrian",
+        "zeilen": "Water sport",
+        "skateboarden": "Sports",
+        "extreme sporten": "Sports",
+        "vliegsport": "Sports",
+        "mixed martial arts (mma)": "Martial sports",
+        "running": "Athletics",
+        "stierenvechten": "Sports",
+        "cheerleading": "Sports",
+        "competitiesporten": "Sports",
+        "multisportevenement": "Special events (Olympic Games, World Cup, etc.)",
+        "sporttalkshow": "Sports magazines",
+        "exercise": "Fitness and health",
+        "outdoor": "Sports",
+        "schermen": "Sports",
+        # Children
+        "kinderen": "Children's / Youth programs",
+        "kids en familie": "Children's / Youth programs",
+        # Music
+        "muziek": "Music / Ballet / Dance",
+        "ballet": "Ballet",
+        "dans": "Music / Ballet / Dance",
+        "opera": "Musical / Opera",
+        "podiumkunsten": "Performing arts",
+        "awards": "Music / Ballet / Dance",
+        # Arts and culture
+        "beeldende kunst": "Fine arts",
+        "kunstnijverheid": "Handicraft",
+        "boeken & literatuur": "Literature",
+        "religie": "Religion",
+        "geschiedenis": "Documentary",
+        "bloemlezing": "Arts / Culture (without music)",
+        # Social and political issues
+        "samenleving": "Social / Political issues / Economics",
+        "educatie": "Informational / Educational / School programs",
+        "wetenschap": "Education / Science / Factual topics",
+        "natuur": "Nature / Animals / Environment",
+        "natuur en milieu": "Nature / Animals / Environment",
+        "technologie": "Technology / Natural sciences",
+        "dieren": "Nature / Animals / Environment",
+        "gezondheid": "Medicine / Physiology / Psychology",
+        "medisch": "Medicine / Physiology / Psychology",
+        "opvoeden": "Informational / Educational / School programs",
+        "lhbti": "Social / Political issues / Economics",
+        "recht": "Social / Political issues / Economics",
+        "paranormaal": "Detective / Thriller",
+        "landbouw": "Nature / Animals / Environment",
+        # Lifestyle
+        "reizen": "Tourism / Travel",
+        "culinair": "Cooking",
+        "mode": "Fashion",
+        "bouwen en verbouwen": "Leisure hobbies",
+        "doe-het-zelf": "Leisure hobbies",
+        "home & garden": "Gardening",
+        "shoppen": "Advertisement / Shopping",
+        "verzamelen": "Leisure hobbies",
+        "veiling": "Advertisement / Shopping",
+        "auto's": "Motoring",
+        "motors": "Motoring",
+        # Entertainment and shows
+        "gamen": "Game show / Quiz / Contest",
+        "entertainment": "Show / Game show",
+        "cabaret": "Variety show",
+        "variété": "Variety show",
+        "spelshow": "Game show / Quiz / Contest",
+        "talkshow": "Talk show",
+        "reality": "Variety show",
+        "reality-competitie": "Game show / Quiz / Contest",
+        "event": "Show / Game show",
+        "consumentenprogramma's": "Show / Game show",
+        "soap": "Soap / Melodrama / Folkloric",
+        "erotiek": "Adult movie / Drama",
+        "erotisch": "Adult movie / Drama",
+    }
+
+    # Maps a DVB subcategory (lowercase) to its main category, so the main category can be dropped
+    # when a more specific subcategory is present for the same programme.
+    DVB_PRIORITY = {
+        "detective / thriller": "Movie / Drama",
+        "adventure / western / war": "Movie / Drama",
+        "science fiction / fantasy / horror": "Movie / Drama",
+        "comedy": "Movie / Drama",
+        "soap / melodrama / folkloric": "Movie / Drama",
+        "romance": "Movie / Drama",
+        "serious / classical / religious / historical movie / drama": "Movie / Drama",
+        "adult movie / drama": "Movie / Drama",
+        "talk show": "Show / Game show",
+        "game show / quiz / contest": "Show / Game show",
+        "variety show": "Show / Game show",
+        "football / soccer": "Sports",
+        "team sports (excluding football)": "Sports",
+        "tennis / squash": "Sports",
+        "athletics": "Sports",
+        "motor sport": "Sports",
+        "water sport": "Sports",
+        "equestrian": "Sports",
+        "martial sports": "Sports",
+        "sports magazines": "Sports",
+        "fitness and health": "Sports",
+        "special events (olympic games, world cup, etc.)": "Sports",
+        "news / weather report": "News / Current affairs",
+        "documentary": "News / Current affairs",
+        "discussion / interview / debate": "News / Current affairs",
+        "cartoons / puppets": "Children's / Youth programs",
+        "ballet": "Music / Ballet / Dance",
+        "rock / pop": "Music / Ballet / Dance",
+        "musical / opera": "Music / Ballet / Dance",
+        "performing arts": "Arts / Culture (without music)",
+        "fine arts": "Arts / Culture (without music)",
+        "religion": "Arts / Culture (without music)",
+        "popular culture / traditional arts": "Arts / Culture (without music)",
+        "literature": "Arts / Culture (without music)",
+        "handicraft": "Leisure hobbies",
+        "fashion": "Leisure hobbies",
+        "motoring": "Leisure hobbies",
+        "tourism / travel": "Leisure hobbies",
+        "cooking": "Leisure hobbies",
+        "gardening": "Leisure hobbies",
+        "advertisement / shopping": "Leisure hobbies",
+        "education / science / factual topics": "Social / Political issues / Economics",
+        "nature / animals / environment": "Social / Political issues / Economics",
+        "technology / natural sciences": "Social / Political issues / Economics",
+        "medicine / physiology / psychology": "Social / Political issues / Economics",
+        "economics / social advisory": "Social / Political issues / Economics",
+        "remarkable people": "Social / Political issues / Economics",
+        "informational / educational / school programs": "Social / Political issues / Economics",
+        "magazines / reports / documentary": "Social / Political issues / Economics",
+    }
+
     def __init__(self, database_connection: sqlite3.Connection):
         """
         Initialize XMLTVWriter.
@@ -102,9 +293,27 @@ class XMLTVWriter:
                     etree.SubElement(programme, "date").text = details["date"]
 
                 if "categories" in details:
-                    # TODO: Offer translation option that adds DVB-EPG compatible types
+                    # Write the original categories, as they may be useful to other applications
                     for category in details["categories"]:
                         etree.SubElement(programme, "category", attrib={"lang": self._lang}).text = category
+
+                    # Collect all matching DVB categories
+                    dvb_codes = set()
+                    for category in details["categories"]:
+                        dvb_code = self.GENRE_MAP.get(category.lower())
+                        if dvb_code:
+                            dvb_codes.add(dvb_code)
+                    # Remove main categories when a more specific subcategory is present
+                    to_remove = set()
+                    for code in dvb_codes:
+                        parent = self.DVB_PRIORITY.get(code.lower())
+                        if parent in dvb_codes:
+                            to_remove.add(parent)
+                    dvb_codes -= to_remove
+                    # Additionally write a single DVB category (writing more than one makes
+                    # TVHeadend accumulate categories over repeated EPG updates)
+                    if dvb_codes:
+                        etree.SubElement(programme, "category", attrib={"lang": "en"}).text = sorted(dvb_codes)[0]
 
                 if "img" in details:
                     etree.SubElement(programme, "icon", attrib={"src": details["img"]})

--- a/classes/xmltvwriter.py
+++ b/classes/xmltvwriter.py
@@ -106,6 +106,9 @@ class XMLTVWriter:
                     for category in details["categories"]:
                         etree.SubElement(programme, "category", attrib={"lang": self._lang}).text = category
 
+                if "img" in details:
+                    etree.SubElement(programme, "icon", attrib={"src": details["img"]})
+
                 if "country" in details:
                     etree.SubElement(programme, "country").text = details["country"]
 

--- a/classes/ziggoepggrabber.py
+++ b/classes/ziggoepggrabber.py
@@ -159,6 +159,8 @@ class ZiggoGoEpgGrabber:
 
         self._grab_start_time = int(time.time())
 
+        self._tv_system_io.preflight()
+
         if not generate_only:
             channel_ids = self._grab_channels()
             self._grab_programmes(channel_ids=channel_ids)

--- a/classes/ziggoepggrabber.py
+++ b/classes/ziggoepggrabber.py
@@ -232,8 +232,10 @@ class ZiggoGoEpgGrabber:
         logging.info("Getting guide overview data...")
 
         # Determine start point using UTC time as segment codes are in UTC
-        grab_start = datetime.datetime.utcfromtimestamp(self._grab_start_time)
-        segment_datetime = datetime.datetime(year=grab_start.year, month=grab_start.month, day=grab_start.day)
+        grab_start = datetime.datetime.fromtimestamp(self._grab_start_time, tz=datetime.timezone.utc)
+        segment_datetime = datetime.datetime(
+            year=grab_start.year, month=grab_start.month, day=grab_start.day, tzinfo=datetime.timezone.utc
+        )
         end_datetime = segment_datetime + datetime.timedelta(days=self._scan_days)
 
         # Set up session with automatic retries

--- a/classes/ziggoepggrabber.py
+++ b/classes/ziggoepggrabber.py
@@ -82,6 +82,9 @@ class ZiggoGoEpgGrabber:
         except KeyError:
             raise GrabException(f"Configuration file {configuration_file} is missing the settings for the urls to grab")
 
+        # Optional URL, programme icons are skipped if not configured
+        self._epg_img_detail_url = configuration["urls"].get("epg_img_detail")
+
         # Use timezone from configuration file if none was given
         if timezone is None:
             try:
@@ -368,6 +371,10 @@ class ZiggoGoEpgGrabber:
                     details["desc"] = programmedata["longDescription"]
                 elif "shortDescription" in programmedata:
                     details["desc"] = programmedata["shortDescription"]
+
+                # The image service needs the eventId (full crid+imi string), not the programme id
+                if self._epg_img_detail_url and "eventId" in programmedata and "imageVersion" in programmedata:
+                    details["img"] = self._epg_img_detail_url.format(programmedata["eventId"], programmedata["imageVersion"])
 
                 credits = {}
                 if "actors" in programmedata:

--- a/classes/ziggoepggrabber.py
+++ b/classes/ziggoepggrabber.py
@@ -55,6 +55,7 @@ class ZiggoGoEpgGrabber:
         configuration_file="ziggo-nl.yml",
         database_file="ziggogoepg_cache.sqlite3",
         timezone=None,
+        vacuum_interval=7,
     ):
         """
         Initialize ZiggoGoEpgGrabber
@@ -63,6 +64,7 @@ class ZiggoGoEpgGrabber:
         :param scan_days: Number of days to scan for
         :param timezone: Timezone string supported by pytz
         :param database_file: The name and location of teh database file to use
+        :param vacuum_interval: Number of days between database vacuums, 0 vacuums on every grab
         """
         self._tv_system_io = tv_system_io
 
@@ -97,6 +99,7 @@ class ZiggoGoEpgGrabber:
         # Set up options statically (for now)
         self._scan_days = scan_days
         self._timezone = pytz.timezone(timezone)
+        self._vacuum_interval = vacuum_interval
 
         # Create or open database
         self._db = sqlite3.connect(database_file)
@@ -135,6 +138,14 @@ class ZiggoGoEpgGrabber:
             )
         """
         )
+        self._dbcur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+        """
+        )
 
     def __del__(self):
         """Cleanup"""
@@ -154,7 +165,17 @@ class ZiggoGoEpgGrabber:
             self._grab_programmedetails()
 
             logging.info("Cleaning up database...")
-            self._dbcur.execute("VACUUM")
+            row = self._dbcur.execute("SELECT value FROM metadata WHERE key = 'last_vacuum'").fetchone()
+            last_vacuum = int(row[0]) if row else 0
+            days_since_vacuum = (self._grab_start_time - last_vacuum) / 86400
+            if days_since_vacuum >= self._vacuum_interval:
+                self._dbcur.execute("VACUUM")
+                self._dbcur.execute(
+                    "INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_vacuum', ?)", (str(self._grab_start_time),)
+                )
+                self._db.commit()
+            else:
+                logging.info(f"Skipping database vacuum, last run was {days_since_vacuum:.1f} days ago")
         else:
             logging.info("Generate only: skip grabbing new EPG data")
 

--- a/ziggo-nl.yml
+++ b/ziggo-nl.yml
@@ -1,11 +1,11 @@
 # URL's to grab the EPG from
 urls:
     # epg_channel_list: Fixed URL that grabs the channel overview
-    epg_channel_list: "https://prod.spark.ziggogo.tv/eng/web/linear-service/v2/channels?cityId=65535&language=nl&productClass=Orion-DASH"
+    epg_channel_list: "https://spark-prod-nl.gnp.cloud.ziggogo.tv/eng/web/linear-service/v2/channels?cityId=65535&language=nl&productClass=Orion-DASH"
     # epg_segment: URL where a segment with the program overview is loaded from. Must have exactly 1 '{}' entry where the segment ID is filed in.
-    epg_segment: "https://static.spark.ziggogo.tv/eng/web/epg-service-lite/nl/nl/events/segments/{}"
+    epg_segment: "https://staticqbr-prod-nl.gnp.cloud.ziggogo.tv/nld/web/epg-service-lite/nl/nl/events/segments/{}"
     # epg_detail: URL where the details for each program are grabbed from. Must have exactly 1 '{}' entry where the program ID is filed in.
-    epg_detail: "https://prod.spark.ziggogo.tv/eng/web/linear-service/v2/replayEvent/{}?returnLinearContent=true&language=nl"
+    epg_detail: "https://spark-prod-nl.gnp.cloud.ziggogo.tv/eng/web/linear-service/v2/replayEvent/{}?returnLinearContent=true&language=nl"
 
 # Timezone that should be used for the XMLTV file
 timezone: "Europe/Amsterdam"

--- a/ziggo-nl.yml
+++ b/ziggo-nl.yml
@@ -6,6 +6,9 @@ urls:
     epg_segment: "https://staticqbr-prod-nl.gnp.cloud.ziggogo.tv/nld/web/epg-service-lite/nl/nl/events/segments/{}"
     # epg_detail: URL where the details for each program are grabbed from. Must have exactly 1 '{}' entry where the program ID is filed in.
     epg_detail: "https://spark-prod-nl.gnp.cloud.ziggogo.tv/eng/web/linear-service/v2/replayEvent/{}?returnLinearContent=true&language=nl"
+    # epg_img_detail: Optional URL where the programme poster image is located. Must have exactly 2 '{}' entries, the first is
+    # filled in with the eventId (full crid+imi string), the second with the imageVersion.
+    epg_img_detail: "https://staticqbr-prod-nl.gnp.cloud.ziggogo.tv/image-service/intent/{}/posterTile?imageVersion={}&w=400"
 
 # Timezone that should be used for the XMLTV file
 timezone: "Europe/Amsterdam"

--- a/ziggogoepg.py
+++ b/ziggogoepg.py
@@ -18,15 +18,13 @@ LOGGING_FORMAT = "%(asctime)s [%(levelname)8s]: %(message)s"
 
 def main():
     """Program main entry point"""
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=LOGGING_FORMAT)
-    logging.info("Starting ZiggoGo EPG")
-
     parser = argparse.ArgumentParser(description="ZiggoGo EPG grabber", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "-s", "--configuration", default="ziggo-nl", type=str, help="configuration to use", metavar="CONFIGURATION"
     )
     parser.add_argument("-n", "--scan-days", default=14, type=int, help="number of days to grab", metavar="DAYS")
     parser.add_argument("-f", "--file-mode", action="store_true", help="use file mode instead of TVHeadend mode")
+    parser.add_argument("-q", "--quiet", action="store_true", help="only log warnings and errors")
 
     tvh_arg_group = parser.add_argument_group("tvheadend mode", description="Arguments used in TVHeadend mode only (the default)")
     tvh_arg_group.add_argument(
@@ -119,6 +117,9 @@ def main():
     )
 
     args = parser.parse_args()
+
+    logging.basicConfig(stream=sys.stdout, level=logging.WARNING if args.quiet else logging.INFO, format=LOGGING_FORMAT)
+    logging.info("Starting ZiggoGo EPG")
 
     tvh_username = args.tvh_username
     if args.tvh_username_env is not None:

--- a/ziggogoepg.py
+++ b/ziggogoepg.py
@@ -6,6 +6,7 @@ Grabber for the EPG hosted by Ziggo on ziggogo.tv
 """
 import argparse
 import logging
+import os
 import os.path
 import sys
 
@@ -38,18 +39,43 @@ def main():
     tvh_arg_group.add_argument(
         "--tvh-port", default=9981, type=int, help="portnumber of TVHeadend, used for getting the channel list", metavar="PORT_NR"
     )
-    tvh_arg_group.add_argument(
+    tvh_username_group = tvh_arg_group.add_mutually_exclusive_group()
+    tvh_username_group.add_argument(
         "--tvh-username", default="", type=str, help="username of TVHeadend, used for getting the channel list", metavar="USER"
     )
-    tvh_arg_group.add_argument(
+    tvh_username_group.add_argument(
+        "--tvh-username-env",
+        default=None,
+        type=str,
+        help="name of the environment variable to read the TVHeadend username from",
+        metavar="ENV_VAR",
+    )
+    tvh_password_group = tvh_arg_group.add_mutually_exclusive_group()
+    tvh_password_group.add_argument(
         "--tvh-password", default="", type=str, help="password of TVHeadend, used for getting the channel list", metavar="PASS"
+    )
+    tvh_password_group.add_argument(
+        "--tvh-password-env",
+        default=None,
+        type=str,
+        help="name of the environment variable to read the TVHeadend password from, "
+        "avoids the password being visible on the command line",
+        metavar="ENV_VAR",
     )
     tvh_arg_group.add_argument(
         "--tvh-socket",
-        default="/home/hts/.hts/tvheadend/epggrab/xmltv.sock",
+        default=None,
         type=str,
-        help="path to xmltv socket of TVHeadend, used to write the XMLTV data to",
+        help="path to xmltv socket of TVHeadend, used to write the XMLTV data to "
+        f"(default: ask TVHeadend, falling back to {TVHeadendIo.DEFAULT_XMLTV_SOCKET_PATH})",
         metavar="SOCKET",
+    )
+    tvh_arg_group.add_argument(
+        "--tvh-network",
+        default=None,
+        type=str,
+        help="only use channels that have a service on the network with this name (default: use all channels)",
+        metavar="NETWORK",
     )
 
     file_arg_group = parser.add_argument_group(
@@ -94,6 +120,21 @@ def main():
 
     args = parser.parse_args()
 
+    tvh_username = args.tvh_username
+    if args.tvh_username_env is not None:
+        try:
+            tvh_username = os.environ[args.tvh_username_env]
+        except KeyError:
+            logging.error(f"Environment variable '{args.tvh_username_env}' given by --tvh-username-env is not set.")
+            return 1
+    tvh_password = args.tvh_password
+    if args.tvh_password_env is not None:
+        try:
+            tvh_password = os.environ[args.tvh_password_env]
+        except KeyError:
+            logging.error(f"Environment variable '{args.tvh_password_env}' given by --tvh-password-env is not set.")
+            return 1
+
     database_file = os.path.normpath(os.path.join(args.database_location, "ziggogoepg_cache.sqlite3"))
     module_location = os.path.dirname(os.path.abspath(__file__))
     configuration_file = os.path.normpath(os.path.join(module_location, f"{args.configuration}.yml"))
@@ -108,9 +149,10 @@ def main():
         tv_system_io = TVHeadendIo(
             host=args.tvh_host,
             port=args.tvh_port,
-            username=args.tvh_username,
-            password=args.tvh_password,
+            username=tvh_username,
+            password=tvh_password,
             xmltv_socket_path=args.tvh_socket,
+            network=args.tvh_network,
         )
 
     try:

--- a/ziggogoepg.py
+++ b/ziggogoepg.py
@@ -84,6 +84,13 @@ def main():
         "--database-location", default=".", type=str, help="path where the cache database will be created", metavar="PATH"
     )
     tweak_arg_group.add_argument("--generate-only", action="store_true", help="generate XMLTV from an existing cache database")
+    tweak_arg_group.add_argument(
+        "--vacuum-interval",
+        default=7,
+        type=int,
+        help="number of days between cache database vacuums, 0 vacuums on every grab",
+        metavar="DAYS",
+    )
 
     args = parser.parse_args()
 
@@ -113,6 +120,7 @@ def main():
             configuration_file=configuration_file,
             database_file=database_file,
             timezone=args.timezone,
+            vacuum_interval=args.vacuum_interval,
         )
     except GrabException as ex:
         logging.error(str(ex))


### PR DESCRIPTION
## Relationship to PR #9

This PR builds on the ideas from #9 by @BertusG — programme poster images, Dutch-to-DVB genre mapping and the scheduled database vacuum — reimplemented as separate commits with the review feedback from that PR addressed (genre map keys matched case-insensitively in lowercase, the vacuum tradeoff exposed as a `--vacuum-interval` option, comments in English, no season/episode type churn). BertusG is credited in the README acknowledgments. If you prefer to merge #9 first, I am happy to rebase this on top of it.

## What's included

**Fixes**
- Update the Ziggo NL API endpoints to the current `gnp.cloud.ziggogo.tv` hosts
- Replace `datetime.utcfromtimestamp()`, which was removed in Python 3.12

**Features from #9, reworked**
- Programme poster images via an optional `epg_img_detail` URL (built from `eventId`, skipped when absent)
- Dutch-to-DVB genre mapping so TVHeadend gets proper ETSI EN 300 468 categories; the original Dutch category is kept as `<category lang="nl">`
- Vacuum the cache database at most once every `--vacuum-interval` days (default 7) instead of on every run

**New TVHeadend integration features**
- Discover the XMLTV socket path through the TVHeadend API instead of relying on the hardcoded default
- `--tvh-network` to limit grabbing to channels with a service on a named network, listing the available network names when nothing matches
- `--tvh-username-env`/`--tvh-password-env` to keep credentials out of the process list
- Preflight check that the XMLTV socket accepts connections, so a misconfiguration fails before a lengthy grab
- `-q`/`--quiet` to only log warnings and errors, for cron/systemd runs

## Why now

This repo may well receive new attention soon: TVHeadend's new Vue-based web interface actually displays the richness this grabber provides — posters, proper genres, extended programme details. That is what led me to this project in the first place.

All of this is running in production against my own TVHeadend setup (Ziggo NL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)